### PR TITLE
Update main.rs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,12 +5,13 @@ mod runtime;
 fn main() {
     let code = r###"(2 + 2) * 2"###;
 
-    let result = compiler::compile(code);
-
-    if let Ok(expr) = result {
-        let v = runtime::eval(expr);
-        println!("{}", v);
-    } else if let Err(err) = result {
-        println!("{}", err)
+    match compiler::compile(code) {
+        Ok(expr) => {
+            let result = runtime::eval(expr);
+            println!("{}", result);
+        }
+        Err(err) => {
+            println!("Compilation error: {}", err);
+        }
     }
 }


### PR DESCRIPTION
If your compile function yields a Result<Expr, &'static str>, you may want to handle errors more explicitly in your main function. One approach is to employ a match statement to discern between successful compilation and errors.